### PR TITLE
From now on, pressing ctrl+c will stop the current calculation, not the

### DIFF
--- a/src/bool_gen.rs
+++ b/src/bool_gen.rs
@@ -2,6 +2,7 @@
 // fastrand::bool() generates a whole u64 and then discards 63 bits.
 // My BoolGen hopefully generates booleans faster.
 
+#[derive(Debug)]
 pub struct BoolGen {
     rng: fastrand::Rng,
     bits: u64,

--- a/src/ctrlc_handler.rs
+++ b/src/ctrlc_handler.rs
@@ -1,0 +1,44 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct CtrlCHandler {
+    was_pressed: Arc<AtomicBool>,
+}
+
+impl CtrlCHandler {
+    pub fn new() -> Self {
+        let this = Self {
+            was_pressed: Arc::new(AtomicBool::new(false)),
+        };
+        let res = ctrlc::set_handler({
+            let this = this.clone();
+            move || {
+                this.was_pressed.store(true, Ordering::SeqCst);
+            }
+        });
+        match res {
+            Ok(()) | Err(ctrlc::Error::NoSuchSignal(_)) | Err(ctrlc::Error::System(_)) => {}
+            Err(ctrlc::Error::MultipleHandlers) => panic!("Ctrl+c handler was set multiple times"),
+        }
+        this
+    }
+
+    pub fn mock() -> Self {
+        Self {
+            was_pressed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn catch(&self) -> Result<(), CtrlCError> {
+        if self.was_pressed.swap(false, Ordering::SeqCst) {
+            Err(CtrlCError)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("ctr+c was pressed")]
+pub struct CtrlCError;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,0 +1,88 @@
+use crate::bool_gen::BoolGen;
+use crate::ctrlc_handler::{CtrlCError, CtrlCHandler};
+use crate::garbage;
+use crate::math::format::{Format, FormattedValue};
+use crate::math::Value;
+use std::io::{self, BufRead, Write};
+
+pub struct EvaluationEnvironemnt {
+    bool_gen: BoolGen,
+    ctrlc_handler: CtrlCHandler,
+}
+
+impl Default for EvaluationEnvironemnt {
+    fn default() -> Self {
+        Self {
+            bool_gen: BoolGen::new(),
+            ctrlc_handler: CtrlCHandler::mock(),
+        }
+    }
+}
+
+impl EvaluationEnvironemnt {
+    pub fn gen_bool(&mut self) -> bool {
+        self.bool_gen.gen()
+    }
+
+    pub fn tick(&mut self) -> Result<(), CtrlCError> {
+        garbage::collect();
+        self.ctrlc_handler.catch()
+    }
+}
+pub struct IoOptions<'a> {
+    pub input: Box<dyn BufRead + 'a>,
+    pub output: Box<dyn Write + 'a>,
+    pub error_output: Box<dyn Write + 'a>,
+    pub output_format: Format,
+    pub are_errors_fatal: bool,
+    pub suggest_help: bool,
+    pub show_welcome_message: bool,
+}
+
+impl<'a> Default for IoOptions<'a> {
+    fn default() -> Self {
+        Self {
+            input: Box::new(std::io::stdin().lock()),
+            output: Box::new(std::io::stdout()),
+            error_output: Box::new(std::io::stderr()),
+            output_format: Format::default(),
+            are_errors_fatal: false,
+            suggest_help: false,
+            show_welcome_message: true,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Environment<'a> {
+    pub evaluation_environment: EvaluationEnvironemnt,
+    pub io_options: IoOptions<'a>,
+}
+
+impl<'a> Environment<'a> {
+    pub fn input(&mut self) -> &mut (dyn BufRead + 'a) {
+        &mut self.io_options.input
+    }
+
+    pub fn output(&mut self) -> &mut (dyn Write + 'a) {
+        &mut self.io_options.output
+    }
+
+    pub fn error_output(&mut self) -> &mut (dyn Write + 'a) {
+        &mut self.io_options.error_output
+    }
+
+    pub fn output_value(&mut self, value: &Value) -> Result<(), io::Error> {
+        let fmt = self.io_options.output_format;
+        writeln!(self.output(), "{}", FormattedValue(fmt, value))?;
+        Ok(())
+    }
+
+    pub fn init_ctrlc_handler(&mut self) {
+        self.evaluation_environment.ctrlc_handler = CtrlCHandler::new();
+    }
+
+    pub fn ignore_ctrlc(&mut self) {
+        let _ = self.evaluation_environment.ctrlc_handler.catch();
+    }
+}

--- a/src/garbage.rs
+++ b/src/garbage.rs
@@ -1,0 +1,22 @@
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::mem::ManuallyDrop;
+
+use crate::expression::Expression;
+
+thread_local! {
+    static GARBAGE: RefCell<VecDeque<Expression>> = RefCell::new(VecDeque::new());
+}
+
+pub fn dispose(expr: Expression) {
+    let expr = ManuallyDrop::new(expr);
+    let _ = GARBAGE.try_with(|garbage| {
+        garbage.borrow_mut().push_back(ManuallyDrop::into_inner(expr));
+    });
+}
+
+pub fn collect() {
+    while let Some(expr) = GARBAGE.with(|garbage| garbage.borrow_mut().pop_front()) {
+        drop(expr);
+    }
+}

--- a/src/math.rs
+++ b/src/math.rs
@@ -3,4 +3,4 @@ mod pow;
 mod value;
 
 pub use pow::pow;
-pub use value::{Undefined, Value};
+pub use value::Value;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,5 @@
+use crate::environment::Environment;
 use crate::math::format::Format;
-use crate::program::Environment;
 use crate::{compile, parse};
 use itertools::Itertools;
 use std::fs;
@@ -24,11 +24,9 @@ fn interpreter_test() {
     .filter(|line| !line.trim_start().starts_with('#'))
     .join("\n");
     let mut output: Vec<u8> = vec![];
-    let mut env = Environment {
-        output: Box::new(&mut output),
-        output_format: Format::Fraction,
-        ..Environment::default()
-    };
+    let mut env = Environment::default();
+    env.io_options.output = Box::new(&mut output);
+    env.io_options.output_format = Format::Fraction;
     let code = parse::parse(&input).unwrap();
     let mut program = compile::compile(code).unwrap();
     program.run(&mut env).unwrap();


### PR DESCRIPTION
whole program. Also fixed a possible bug, where recursive destruction of expressions causes a stack overflow (though I have never encountered it before changing the way ctrl+c is handled).